### PR TITLE
Fix no preview available in slack notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 out/
 *.iml
+venv/

--- a/cloudwatch_to_slack/app.py
+++ b/cloudwatch_to_slack/app.py
@@ -118,6 +118,7 @@ def construct_slack_message(name, description, trigger, dimensions,
     message = {
         'attachments': [
             {
+                'fallback': new_state + ": " + name,
                 'color': COLORS.get(new_state, UNKNOWN_COLOR),
                 'blocks': message_attachments
             }

--- a/cloudwatch_to_slack/requirements.txt
+++ b/cloudwatch_to_slack/requirements.txt
@@ -1,1 +1,2 @@
-pytest~=6.0.2
+pytest~=6.1.1
+iniconfig==1.0.1


### PR DESCRIPTION
Add fallback with state and alarm name to attachment